### PR TITLE
Added powerDown, getCost, getDivergeCost

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Why not?
 # Coming Soon:
 - ~~Version 2 Base Stats from Nov. 21, 2016 Update~~ (Done)
 - ~~How much more dust / candy needed to reach a level target~~ (Done)
-- Lookups by name instead of just ID
+- ~~Lookups by name instead of just ID~~ (Done)
 - Catch probabilities
 - Catch bonuses
 - Flee rates

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Why not?
 
 # Coming Soon:
 - ~~Version 2 Base Stats from Nov. 21, 2016 Update~~ (Done)
-- How much more dust / candy needed to reach a level target
+- ~~How much more dust / candy needed to reach a level target~~ (Done)
 - Lookups by name instead of just ID
 - Catch probabilities
 - Catch bonuses
@@ -118,6 +118,7 @@ Why not?
 - More egg information
 - ~~Gen VII Base Stats (Sun & Moon)~~ (Done)
 - Alternate forms of existing Pokemon
+- Real documentation
 
 ## Coming Less Soon:
 - Battle calculations

--- a/pokemongo/pokemongo.sig
+++ b/pokemongo/pokemongo.sig
@@ -47,6 +47,7 @@ sig
 	 *)
 	val powerUp : pkmn -> pkmn
 	val powerUpN : int -> pkmn -> pkmn
+	val powerDown : pkmn -> pkmn
 	val setLevel : pkmn -> (int * bool) -> pkmn
 	val evolve : int -> pkmn -> pkmn
 
@@ -90,4 +91,6 @@ sig
 	(* Diverge function *)
 	val diverge : (pkmn * pkmn) -> int
 	val divergeL : pkmn list -> (int * pkmn) list
+	val getCost : (int * pkmn) -> {dust : int, candy : int}
+	val getDivergeCost : (int * pkmn) -> {dust : int, candy : int}
 end


### PR DESCRIPTION
Added the powerDown function (for lowering a Pokemon's level by a half level), the getCost function (to find out how much it would cost to power it up n times), and the getDivergeCost function (to map directly over diverge results).

Also updated the README.